### PR TITLE
Add Github Action Integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,11 +1,16 @@
 name: Terraform Validation
 
-on: [push]
+on: [ push ]
 
 jobs:
   test:
-    name: Verify Terraform is valid
+    name: Verify Terraform is valid for ${{ matrix.terraform_dir }}
     runs-on: ubuntu-18.04
+    timeout-minutes: 5
+    container:
+      image: hashicorp/terraform:0.12.19
+    env:
+      AWS_DEFAULT_REGION: us-east-1
     strategy:
       matrix:
         terraform_dir: [main, lambda]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Terraform Validation
 
-on: [ push ]
+on: [ push, pull_request ]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v1
-      - working-directory: ${{ matrix.terraform_dir }}
       - name: "Terraform Init"
         run: terraform init
+        working-directory: ${{ matrix.terraform_dir }}
       - name: "Validate Terraform"
         run: terraform validate
+        working-directory: ${{ matrix.terraform_dir }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,6 @@
 name: Terraform Validation
 
-on: [ push, pull_request ]
+on: [ push ]
 
 jobs:
   test:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,19 @@
+name: Terraform Validation
+
+on: [push]
+
+jobs:
+  test:
+    name: Verify Terraform is valid
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        terraform_dir: [main, lambda]
+
+    steps:
+      - uses: actions/checkout@v1
+      - working-directory: ${{ matrix.terraform_dir }}
+      - name: "Terraform Init"
+        run: terraform init
+      - name: "Validate Terraform"
+        run: terraform validate


### PR DESCRIPTION
Background: In order to improve the quality of our code base and more easily ensure that any change added to our codebase doesn't break it, we should add a Travis CI job to run terraform validate on any PR that is opened against master for Beekeeper-Terraform

The original target of this was to make this CI checks w/ Travis, however I figured since Github Actions is built in I may as well throw it out there as an option and see what everyone prefers

Note: This won't currently run on this repository until merged, but here is the result in my fork: https://github.com/KenFigueiredo/beekeeper-terraform/pull/3